### PR TITLE
fix: Build distributed package for Production properly (remove jsxDEV)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig(
           ],
         },
         minify: true,
-        sourcemap: true,
+        sourcemap: false,
         emptyOutDir: true,
       },
       define: {


### PR DESCRIPTION
`jsxDEV` was in the distributed package